### PR TITLE
Fixed error in Content-Security-Policy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Here are some example CSP declarations for your `.html` pages:
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' foo.com">
 
     <!-- Enable all requests, inline styles, and eval() -->
-    <meta http-equiv="Content-Security-Policy" content="default-src *; style-src 'self' 'unsafe-inline'; script-src: 'self' 'unsafe-inline' 'unsafe-eval'">
+    <meta http-equiv="Content-Security-Policy" content="default-src *; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'">
 
     <!-- Allow XHRs via https only -->
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' https:">


### PR DESCRIPTION
There's an error in the example. There's a colon after script-src that shouldn't be there.