### PR TITLE
Update whitelist version to 2.0.0 to support older versions of the CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-whitelist",
-  "version": "1.1.1-dev",
+  "version": "2.0.0-dev",
   "description": "Cordova Whitelist Plugin",
   "cordova": {
     "platforms": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-whitelist"
-      version="1.1.1-dev">
+      version="2.0.0-dev">
     <name>Whitelist</name>
     <description>Cordova Network Whitelist Plugin</description>
     <license>Apache 2.0</license>


### PR DESCRIPTION
Older versions of the CLI using cordova-app-hello-world template that references v1 of this plugin and adding a cordova-ios 4.x requirement will cause warnings to show up on existing projects. This is rated as one of the most voted cordova problems on stack overflow:
http://stackoverflow.com/questions/30991828/cordova-plugin-whitelist-failed-asking-for-cordova-ios-4/30992364#30992364
I know it's just a warning but users get confused.