### PR TITLE
Updated cordova-android and ios semver

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -27,8 +27,8 @@
     <keywords>cordova,whitelist,policy</keywords>
 
     <engines>
-      <engine name="cordova-android" version=">=4.0.0-dev" />
-      <engine name="cordova-ios" version=">=4.0.0-dev" />
+      <engine name="cordova-android" version=">=4" />
+      <engine name="cordova-ios" version=">=4" />
     </engines>
 
     <platform name="android">


### PR DESCRIPTION
This is forcing cordova-android 4.1.1 instead of allowing cordova-android@5