### PR TITLE
CB-10866: Adding engine info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,13 @@
     "ecosystem:cordova",
     "cordova-android"
   ],
-  "engines": [
-    {
-      "name": "cordova-android",
-      "version": ">=4.0.0"
+  "engines": {
+    "cordovaDependencies": {
+      "0.0.0": {
+        "cordova-android": ">=4.0.0"
+      }
     }
-  ],
+  },
   "author": "Apache Software Foundation",
   "license": "Apache 2.0"
 }


### PR DESCRIPTION
Putting the version constraint at 0.0.0 because the whitelist used to be part of the platform