### PR TITLE
CB-11391 android: Does not pass sonarqube scan

### DIFF
--- a/src/android/WhitelistPlugin.java
+++ b/src/android/WhitelistPlugin.java
@@ -118,7 +118,7 @@ public class WhitelistPlugin extends CordovaPlugin {
 
     @Override
     public Boolean shouldAllowRequest(String url) {
-        if (Boolean.TRUE == shouldAllowNavigation(url)) {
+        if (shouldAllowNavigation(url)) {
             return true;
         }
         if (allowedRequests.isUrlWhiteListed(url)) {


### PR DESCRIPTION
The problem is "Correctness - Suspicious reference comparison of Boolean values",
which sonarqube considers major.