### PR TITLE
CB-11795 Add 'protective' entry to cordovaDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "cordovaDependencies": {
       "0.0.0": {
         "cordova-android": ">=4.0.0"
+      },
+      "2.0.0": {
+        "cordova": ">100"
       }
     }
   },


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

The entry is required to protect end-users from fetching edge versions of the plugin by incompatible version of cordova. This also assumes that we will not introduce any regressions in compatibility w/ cordova in minor and patch releases. On every major release we will need to add similar entry with _next_ major version.