### PR TITLE
Incorrect default value listing for Intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ By default, navigations only to `file://` URLs, are allowed. To allow others URL
 
 ## Intent Whitelist
 Controls which URLs the app is allowed to ask the system to open.
-By default, no external URLs are allowed.
+By default, all external URLs and intent types are allowed, it is advised to narrow this down based on each app's needs.
 
 On Android, this equates to sending an intent of type BROWSEABLE.
 


### PR DESCRIPTION
Within the "Intent Whitelist" subheading the statement saying that the default blocks all external URLs is incorrect. Currently a newly generated Cordova project actually allows http://*/*, https://*/*, tel:*, sms:*, mailto:*, geo:* and depending on platform may include items such as market:* too. These would be classed as external URLs so I'd say the documentation should say that all URLs are allowed and advise developers to manually put in their own intent declarations that narrow this down.

Note: Could not find an applicable area in JIRA to post this since it's a documentation fix. All non plugin documentation reporting is done via GitHub issues but plugins seem to be in this limbo since the documentation and plugin itself are all under the same GitHub directory :man_shrugging: 

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All, with specific options depending on platform such as market:* as stated above

### What does this PR do?
Edit documentation text, not actually implement any code

### What testing has been done on this change?
Generated a brand new app using the newest build of the Cordova CLI, added Android as a platform and built. The initially created config.xml in the root of the app folder has the options as listed above all listed with the wildstar attributes.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
