### PR TITLE
Remove information about cordova-android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,10 +39,6 @@
         </config-file>
 
         <source-file src="src/android/WhitelistPlugin.java" target-dir="src/org/apache/cordova/whitelist" />
-
-        	<info>
-               This plugin is only applicable for versions of cordova-android greater than 4.0. If you have a previous platform version, you do *not* need this plugin since the whitelist will be built in.
-          </info>
     </platform>
 
 </plugin>


### PR DESCRIPTION
This messages is applicable only to cordova-android version 3.0 or lower, which could be considered ancient by now.
That message produce noise in the build output

### Platforms affected

Only build time

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
