### PR TITLE
docs: apply syntax highlighting to XML samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ On Android, support for CSP within the system webview starts with KitKat (but is
 
 Here are some example CSP declarations for your `.html` pages:
 
-```xml
+```html
 <!-- Good default declaration:
     * gap: is required only on iOS (when using UIWebView) and is needed for JS->native communication
     * https://ssl.gstatic.com is required only on Android and is needed for TalkBack to function properly

--- a/README.md
+++ b/README.md
@@ -45,22 +45,24 @@ top-level navigations only.
 
 By default navigations are only allowed to `file://` URLs. To allow others URLs, you must add `<allow-navigation>` tags to your `config.xml`:
 
-    <!-- Allow links to example.com -->
-    <allow-navigation href="http://example.com/*" />
+```xml
+<!-- Allow links to example.com -->
+<allow-navigation href="http://example.com/*" />
 
-    <!-- Wildcards are allowed for the protocol, as a prefix
-         to the host, or as a suffix to the path -->
-    <allow-navigation href="*://*.example.com/*" />
+<!-- Wildcards are allowed for the protocol, as a prefix
+     to the host, or as a suffix to the path -->
+<allow-navigation href="*://*.example.com/*" />
 
-    <!-- A wildcard can be used to whitelist the entire network,
-         over HTTP and HTTPS.
-         *NOT RECOMMENDED* -->
-    <allow-navigation href="*" />
+<!-- A wildcard can be used to whitelist the entire network,
+     over HTTP and HTTPS.
+     *NOT RECOMMENDED* -->
+<allow-navigation href="*" />
 
-    <!-- The above is equivalent to these three declarations -->
-    <allow-navigation href="http://*/*" />
-    <allow-navigation href="https://*/*" />
-    <allow-navigation href="data:*" />
+<!-- The above is equivalent to these three declarations -->
+<allow-navigation href="http://*/*" />
+<allow-navigation href="https://*/*" />
+<allow-navigation href="data:*" />
+```
 
 Quirks: on Android it also applies to iframes for non-http(s) schemes.
 
@@ -70,29 +72,31 @@ Controls which URLs the app is allowed to ask the system to open.
 
 In `config.xml`, add `<allow-intent>` tags, like this:
 
-    <!-- Allow links to web pages to open in a browser -->
-    <allow-intent href="http://*/*" />
-    <allow-intent href="https://*/*" />
+```xml
+<!-- Allow links to web pages to open in a browser -->
+<allow-intent href="http://*/*" />
+<allow-intent href="https://*/*" />
 
-    <!-- Allow links to example.com to open in a browser -->
-    <allow-intent href="http://example.com/*" />
+<!-- Allow links to example.com to open in a browser -->
+<allow-intent href="http://example.com/*" />
 
-    <!-- Wildcards are allowed for the protocol, as a prefix
-         to the host, or as a suffix to the path -->
-    <allow-intent href="*://*.example.com/*" />
+<!-- Wildcards are allowed for the protocol, as a prefix
+     to the host, or as a suffix to the path -->
+<allow-intent href="*://*.example.com/*" />
 
-    <!-- Allow SMS links to open messaging app -->
-    <allow-intent href="sms:*" />
+<!-- Allow SMS links to open messaging app -->
+<allow-intent href="sms:*" />
 
-    <!-- Allow tel: links to open the dialer -->
-    <allow-intent href="tel:*" />
+<!-- Allow tel: links to open the dialer -->
+<allow-intent href="tel:*" />
 
-    <!-- Allow geo: links to open maps -->
-    <allow-intent href="geo:*" />
+<!-- Allow geo: links to open maps -->
+<allow-intent href="geo:*" />
 
-    <!-- Allow all unrecognized URLs to open installed apps
-         *NOT RECOMMENDED* -->
-    <allow-intent href="*" />
+<!-- Allow all unrecognized URLs to open installed apps
+     *NOT RECOMMENDED* -->
+<allow-intent href="*" />
+```
 
 Without any `<allow-intent>` tags, no requests to external URLs are allowed. However, the default Cordova application includes a quite liberal set of `allow-intent` entries by default. It is advised to narrow this down based on each app's needs.
 
@@ -110,21 +114,23 @@ Note: We suggest you use a Content Security Policy (see below), which is more se
 
 In `config.xml`, add `<access>` tags, like this:
 
-    <!-- Allow images, xhrs, etc. to google.com -->
-    <access origin="http://google.com" />
-    <access origin="https://google.com" />
+```xml
+<!-- Allow images, xhrs, etc. to google.com -->
+<access origin="http://google.com" />
+<access origin="https://google.com" />
 
-    <!-- Access to the subdomain maps.google.com -->
-    <access origin="http://maps.google.com" />
+<!-- Access to the subdomain maps.google.com -->
+<access origin="http://maps.google.com" />
 
-    <!-- Access to all the subdomains on google.com -->
-    <access origin="http://*.google.com" />
+<!-- Access to all the subdomains on google.com -->
+<access origin="http://*.google.com" />
 
-    <!-- Enable requests to content: URLs -->
-    <access origin="content:///*" />
+<!-- Enable requests to content: URLs -->
+<access origin="content:///*" />
 
-    <!-- Don't block any requests -->
-    <access origin="*" />
+<!-- Don't block any requests -->
+<access origin="*" />
+```
 
 Without any `<access>` tags, only requests to `file://` URLs are allowed. However, the default Cordova application includes `<access origin="*">` by default.
 
@@ -142,26 +148,28 @@ On Android, support for CSP within the system webview starts with KitKat (but is
 
 Here are some example CSP declarations for your `.html` pages:
 
-    <!-- Good default declaration:
-        * gap: is required only on iOS (when using UIWebView) and is needed for JS->native communication
-        * https://ssl.gstatic.com is required only on Android and is needed for TalkBack to function properly
-        * Disables use of eval() and inline scripts in order to mitigate risk of XSS vulnerabilities. To change this:
-            * Enable inline JS: add 'unsafe-inline' to default-src
-            * Enable eval(): add 'unsafe-eval' to default-src
-    -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com; style-src 'self' 'unsafe-inline'; media-src *">
+```xml
+<!-- Good default declaration:
+    * gap: is required only on iOS (when using UIWebView) and is needed for JS->native communication
+    * https://ssl.gstatic.com is required only on Android and is needed for TalkBack to function properly
+    * Disables use of eval() and inline scripts in order to mitigate risk of XSS vulnerabilities. To change this:
+        * Enable inline JS: add 'unsafe-inline' to default-src
+        * Enable eval(): add 'unsafe-eval' to default-src
+-->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com; style-src 'self' 'unsafe-inline'; media-src *">
 
-    <!-- Allow everything but only from the same origin and foo.com -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' foo.com">
+<!-- Allow everything but only from the same origin and foo.com -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' foo.com">
 
-    <!-- This policy allows everything (eg CSS, AJAX, object, frame, media, etc) except that 
-        * CSS only from the same origin and inline styles,
-        * scripts only from the same origin and inline styles, and eval()
-    -->
-    <meta http-equiv="Content-Security-Policy" content="default-src *; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'">
+<!-- This policy allows everything (eg CSS, AJAX, object, frame, media, etc) except that 
+    * CSS only from the same origin and inline styles,
+    * scripts only from the same origin and inline styles, and eval()
+-->
+<meta http-equiv="Content-Security-Policy" content="default-src *; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'">
 
-    <!-- Allows XHRs only over HTTPS on the same domain. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' https:">
+<!-- Allows XHRs only over HTTPS on the same domain. -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' https:">
 
-    <!-- Allow iframe to https://cordova.apache.org/ -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-src 'self' https://cordova.apache.org">
+<!-- Allow iframe to https://cordova.apache.org/ -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-src 'self' https://cordova.apache.org">
+```


### PR DESCRIPTION
I had to convert the indented code blocks to fenced ones, so best ignore space changes.