### PR TITLE
ci(travis): update osx xcode image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ node_js: 12
 
 _ios: &_ios
   os: osx
-  osx_image: xcode10.3
+  osx_image: xcode11.5
 
 _android: &_android
   language: android

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ node_js: 12
 
 _ios: &_ios
   os: osx
-  osx_image: xcode11.5
+  osx_image: xcode11.6
 
 _android: &_android
   language: android
@@ -117,4 +117,3 @@ script:
     else
       $PARAMEDIC_COMMAND --config ./pr/$PLATFORM --plugin $PARAMEDIC_PLUGIN_TO_TEST --buildName $PARAMEDIC_BUILDNAME;
     fi
-


### PR DESCRIPTION
### Motivation and Context

Use the supported version of Xcode that is needed for the latest release of Cordova-iOS

OSX XCode Image: 11.5