### PR TITLE
ci: add node-14.x to workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - ANDROID_BUILD_TOOLS_VERSION=29.0.2
 
 language: node_js
-node_js: 12
+node_js: 14
 
 # yaml anchor/alias: https://medium.com/@tommyvn/travis-yml-dry-with-anchors-8b6a3ac1b027
 


### PR DESCRIPTION
### Motivation, Context & Description

* Test with Node 14.x
* Added Node 14.x CI all workflow configurations.

See https://github.com/apache/cordova/issues/223 for more details.


### Testing

* No local testing required.
* Use CI service test results

### Checklist

- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
