### PR TITLE
breaking: deprecate plugin

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -15,6 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+
+github:
+  description: "[DEPRECATED] Apache Cordova - Whitelist Plugin"
+
 notifications:
   commits:              commits@cordova.apache.org
   issues:               issues@cordova.apache.org

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ description: Whitelist external content accessible by your app.
 
 This plugin implements a whitelist policy for navigating the application webview on Cordova 4.0
 
+### Deprecation Notice
+
+With the Allow List functionality now integrated into the core of Cordova Android (10.x and greater), this plugin is no longer required.
+
+Existing projects using Cordova Android 10 or greater should remove this plugin with the following command:
+
+```bash
+cordova plugin rm cordova-plugin-whitelist
+```
+
 ## Installation
 
 You can install whitelist plugin with Cordova CLI, from npm:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "cordova-android": ">=4.0.0"
       },
       "2.0.0": {
-        "cordova": ">100"
+        "cordova": ">100",
+        "cordova-android": ">=4.0.0 <10.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
         "cordova-android": ">=4.0.0"
       },
       "2.0.0": {
-        "cordova": ">100",
         "cordova-android": ">=4.0.0 <10.0.0"
       }
     }

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,7 @@
     <keywords>cordova,whitelist,policy</keywords>
 
     <engines>
-      <engine name="cordova-android" version=">=4.0.0" />
+      <engine name="cordova-android" version=">=4.0.0 <10.0.0" />
     </engines>
 
     <platform name="android">


### PR DESCRIPTION
### Platforms affected

Android

### Motivation, Context & Description

This plugin, which only supports Android, is being integrated into the core of the Cordova Android platform.

https://github.com/apache/cordova-android/pull/1138

This plugin will no longer be required in the next major release of Cordova Android, if the PR is merged in before release.

### Checklist

- [x] I've updated the documentation if necessary
